### PR TITLE
Rework required for rebase on .org django bootstrap Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,12 +3,7 @@
 .gitignore
 .tox
 .travis.yml
-AUTHORS.rst
-CHANGELOG.rst
-LICENSE
-MANIFEST.in
 Makefile
-README.rst
 docs/
 tox.ini
 ve/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,25 @@
-FROM praekeltfoundation/python-base:3.6
+FROM praekeltfoundation/django-bootstrap:py3
 
 ARG EXTRA_DEPS
 
 ENV DJANGO_SETTINGS_MODULE=project.settings
+ENV SKIP_MIGRATIONS=1
 
 # Git is required because one of the pip requirements is pulled from github.
 RUN apt-get update && apt-get install -y git gcc netcat $EXTRA_DEPS gettext libgettextpo-dev
 
-RUN mkdir /static
-
-WORKDIR /app/
-
-COPY ./requirements /app/requirements
-
-RUN pip3 install --no-cache-dir -r /app/requirements/requirements.txt --src /usr/local/src
+RUN mkdir -p /app/static
 
 COPY . /app/
 
+WORKDIR /app/
+
+RUN pip3 install --no-cache-dir -r /app/requirements/requirements.txt --src /usr/local/src
+RUN pip install -e .
+
+RUN BUILDER="true" django-admin collectstatic --noinput
 RUN BUILDER="true" python manage.py compilemessages
 
 EXPOSE 8000
+
+CMD ["project.wsgi:application"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,15 @@ RUN apt-get update && apt-get install -y git gcc netcat $EXTRA_DEPS gettext libg
 
 RUN mkdir -p /app/static
 
-COPY . /app/
-
 WORKDIR /app/
 
-RUN pip3 install --no-cache-dir -r /app/requirements/requirements.txt --src /usr/local/src
+# Copy and install requirements.txt first. If requirements did not change, the
+# cached layers can be re-used, which significantly speeds up the build.
+COPY ./requirements/requirements.txt /app/requirements.txt
+RUN pip3 install --no-cache-dir -r /app/requirements.txt --src /usr/local/src
+
+COPY . /app/
+
 RUN pip install -e .
 
 RUN BUILDER="true" django-admin collectstatic --noinput

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM praekeltfoundation/django-bootstrap:py3
 ARG EXTRA_DEPS
 
 ENV DJANGO_SETTINGS_MODULE=project.settings
-ENV SKIP_MIGRATIONS=1
 
 # Git is required because one of the pip requirements is pulled from github.
 RUN apt-get update && apt-get install -y git gcc netcat $EXTRA_DEPS gettext libgettextpo-dev

--- a/project/settings.py
+++ b/project/settings.py
@@ -25,7 +25,7 @@ SESSION_COOKIE_AGE = 86400
 AUTH_USER_MODEL = "authentication_service.CoreUser"
 
 STATIC_URL = "/static/"
-STATIC_ROOT = "/static/"
+STATIC_ROOT = "/app/static"
 
 LOCALE_PATHS = [
     "locale"
@@ -206,6 +206,11 @@ LOGGING = {
             "handlers": ["console"],
             "propagate": False,
         },
+        "celery": {
+            "level": "DEBUG",
+            "handlers": ["console"],
+            "propagate": False,
+        },
     },
 }
 
@@ -223,10 +228,12 @@ IS_WORKER = env.str("CELERY_APP", None) == "project"
 if IS_WORKER:
     # Email settings
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-    EMAIL_HOST = "email-smtp.eu-west-1.amazonaws.com"
-    EMAIL_HOST_USER = env.str("EMAIL_HOST_USER")
-    EMAIL_HOST_PASSWORD = env.str("EMAIL_HOST_PASSWORD")
-    EMAIL_USE_TLS = True
+    EMAIL_HOST = env.str("EMAIL_HOST", "localhost")
+    EMAIL_HOST_USER = env.str("EMAIL_USER", "")
+    EMAIL_HOST_PASSWORD = env.str("EMAIL_PASSWORD", "")
+    EMAIL_USE_TLS = env.bool("EMAIL_USE_TLS", False)
+    EMAIL_USE_SSL = env.bool("EMAIL_USE_SSL", False)
+    EMAIL_TIMEOUT = env.int("EMAIL_TIMEOUT", None)
 
 # NOTE: Celery workers do not currently require the apis either.
 if not any([IS_WORKER, env.bool("BUILDER", False)]):

--- a/project/wsgi.py
+++ b/project/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "authentication_service.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project.settings")
 
 application = get_wsgi_application()


### PR DESCRIPTION
Achtung! Currently the .org Django bootstrap image changes the ownership of the source directory and all files and directories underneath it when running in docker compose. This is definitely not ideal. I need to figure out if it is the celery instance or the auth service container doing this (for gunicorn and nginx), or whether it is both.