### PR TITLE
Changed date parser to handle a json type object as an argument with …

### DIFF
--- a/authentication_service/tests/test_integration.py
+++ b/authentication_service/tests/test_integration.py
@@ -85,7 +85,6 @@ class IntegrationTestCase(TestCase):
             description="Desc"
         )
 
-
     def test_client_list(self):
         # Authorize user
         self.client.login(username="test_user_1", password="password")
@@ -335,22 +334,22 @@ class IntegrationTestCase(TestCase):
         # DOB
         response = self.client.get(
             "/api/v1/users?birth_date="
-            "[2007-01-01T10:44:47.021Z,2018-04-26T10:44:47.021Z]"
+            '{"from":"2007-01-01T10:44:47.021Z","to":"2018-04-26T10:44:47.021Z]"}'
         )
         self.assertEqual(len(response.json()), len(users))
         response = self.client.get(
             "/api/v1/users?birth_date="
-            "[2007-01-01,2018-04-26]"
+            '{"from":"2007-01-01","to":"2018-04-26"}'
         )
         self.assertEqual(len(response.json()), len(users))
         response = self.client.get(
             "/api/v1/users?birth_date="
-            "[2006-01-01T10:44:47.021Z,None]"
+            '{"from":"2006-01-01T10:44:47.021Z"}'
         )
         self.assertEqual(len(response.json()), len(users))
         response = self.client.get(
             "/api/v1/users?birth_date="
-            "[None, 1980-01-01T10:44:47.021Z]"
+            '{"to":"1980-01-01T10:44:47.021Z"}'
         )
         self.assertEqual(len(response.json()), 0)
 
@@ -401,28 +400,34 @@ class IntegrationTestCase(TestCase):
         self.client.login(username="test_user_3", password="password")
         response = self.client.get(
             "/api/v1/users?birth_date="
-            "[None, None]"
+            '{"from":null,"to":null}'
         )
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.content, b"Date range list does not contain a date object")
+        self.assertEqual(response.content, b"Date range object does not contain any date object values")
 
         response = self.client.get(
             "/api/v1/users?birth_date="
-            "[1, 2, 3]"
+            '{"from":1,"to":2,"too":3}'
         )
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.content, b"Date range list with length:3, exceeds max length of 2")
+        self.assertEqual(response.content, b"Date range object with length:3, exceeds max length of 2")
 
         response = self.client.get(
             "/api/v1/users?birth_date="
-            "[None, None, None]"
+            '{"from":null,"to":null,"too":null}'
         )
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.content, b"Date range list with length:3, exceeds max length of 2")
+        self.assertEqual(response.content, b"Date range object with length:3, exceeds max length of 2")
 
         response = self.client.get(
             "/api/v1/users?birth_date="
-            "[1, 2]"
+            '{"from":"1","to":"2"}'
         )
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.content, b"Date value(1) does not have correct format YYYY-MM-DD")
+
+        response = self.client.get(
+            "/api/v1/users?birth_date="
+            '{"from":"1","to"}'
+        )
+        self.assertEqual(response.status_code, 400)

--- a/authentication_service/tests/test_utils.py
+++ b/authentication_service/tests/test_utils.py
@@ -1,6 +1,7 @@
 import datetime
 
 from django.contrib.auth import get_user_model
+from django.core.exceptions import SuspiciousOperation
 from django.test import TestCase
 
 from authentication_service import utils, exceptions
@@ -53,7 +54,7 @@ class DateFilterTestCase(TestCase):
 
     def test_string_range(self):
         value = utils.range_filter_parser(
-            "[2007-01-01T10:44:47.021Z,2018-04-26T10:44:47.021Z]")
+            '{"from":"2007-01-01T10:44:47.021Z","to":"2018-04-26T10:44:47.021Z"}')
         self.assertEqual(
             value,
             ("range", [
@@ -61,7 +62,7 @@ class DateFilterTestCase(TestCase):
                 datetime.datetime(2018, 4, 26, 10, 44, 47)
             ])
         )
-        value = utils.range_filter_parser("[2007-01-01,2018-04-26]")
+        value = utils.range_filter_parser('{"from":"2007-01-01","to":"2018-04-26"}')
         self.assertEqual(
             value,
             ("range", [
@@ -70,19 +71,19 @@ class DateFilterTestCase(TestCase):
             ])
         )
         value = utils.range_filter_parser(
-            "[2007-01-01T10:44:47.021Z,None]")
+            '{"from":"2007-01-01T10:44:47.021Z"}')
         self.assertEqual(
             value,
             ("gte", datetime.datetime(2007, 1, 1, 10, 44, 47))
         )
         value = utils.range_filter_parser(
-            "[None,2018-04-26]")
+            '{"to":"2018-04-26"}')
         self.assertEqual(
             value,
             ("lte", datetime.datetime(2018, 4, 26, 0, 0))
         )
         value = utils.range_filter_parser(
-            "[2007-01-01,2018-04-26T10:44:47.021Z]")
+            '{"from":"2007-01-01","to":"2018-04-26T10:44:47.021Z"}')
         self.assertEqual(
             value,
             ("range", [
@@ -90,17 +91,22 @@ class DateFilterTestCase(TestCase):
                 datetime.datetime(2018, 4, 26, 10, 44, 47)
             ])
         )
+
     def test_list_range(self):
         value = utils.range_filter_parser(
-            [datetime.date(2007, 1, 1), datetime.date(2018, 1, 26)])
+            {
+                "from": datetime.date(2007, 1, 1),
+                "to": datetime.date(2018, 1, 26)
+            }
+        )
         self.assertEqual(
             value,
             ("range", [datetime.date(2007, 1, 1), datetime.date(2018, 1, 26)])
         )
-        value = utils.range_filter_parser([
-            datetime.datetime(2007, 1, 1, 5, 20, 10),
-            datetime.datetime(2018, 1, 26, 5, 20, 10)
-        ])
+        value = utils.range_filter_parser({
+            "from": datetime.datetime(2007, 1, 1, 5, 20, 10),
+            "to": datetime.datetime(2018, 1, 26, 5, 20, 10)
+        })
         self.assertEqual(
             value,
             ("range", [
@@ -109,21 +115,21 @@ class DateFilterTestCase(TestCase):
             ])
         )
         value = utils.range_filter_parser(
-            [datetime.date(2007, 1, 1), None])
+            {"from": datetime.date(2007, 1, 1)})
         self.assertEqual(
             value,
             ("gte", datetime.date(2007, 1, 1))
         )
         value = utils.range_filter_parser(
-            [None, datetime.date(2018, 1, 26)])
+            {"to": datetime.date(2018, 1, 26)})
         self.assertEqual(
             value,
             ("lte", datetime.date(2018, 1, 26))
         )
-        value = utils.range_filter_parser([
-            datetime.date(2007, 1, 1),
-            datetime.datetime(2018, 1, 26, 5, 20, 10)
-        ])
+        value = utils.range_filter_parser({
+            "from": datetime.date(2007, 1, 1),
+            "to": datetime.datetime(2018, 1, 26, 5, 20, 10)
+        })
         self.assertEqual(
             value,
             ("range", [
@@ -134,48 +140,60 @@ class DateFilterTestCase(TestCase):
 
     def test_error_list_range(self):
         with self.assertRaises(exceptions.BadRequestException) as e:
-            value = utils.range_filter_parser([
-                1,2,3
-            ])
+            value = utils.range_filter_parser({
+                "from": 1,
+                "to": 2,
+                "too": 3
+            })
             self.assertEqual(
                 e.message,
-                "Date range list with length:3, exceeds max length of 2"
+                "Date range object with length:3, exceeds max length of 2"
             )
 
         with self.assertRaises(exceptions.BadRequestException) as e:
-            value = utils.range_filter_parser([
-                None, None, None
-            ])
+            value = utils.range_filter_parser({
+                "from": None,
+                "to": None,
+                "too": None
+            })
             self.assertEqual(
                 e.message,
-                "Date range list with length:3, exceeds max length of 2"
+                "Date range object with length:3, exceeds max length of 2"
             )
 
         with self.assertRaises(exceptions.BadRequestException) as e:
-            value = utils.range_filter_parser([
-                None, None
-            ])
+            value = utils.range_filter_parser({
+                "from": None,
+                "to": None
+            })
             self.assertEqual(
                 e.message,
-                "Date range list does not contain a date object"
+                "Date range object does not contain any date object values"
             )
 
         with self.assertRaises(exceptions.BadRequestException) as e:
-            value = utils.range_filter_parser("[None, None, None]")
+            value = utils.range_filter_parser([1, 2, 3])
             self.assertEqual(
                 e.message,
-                "Date range list with length:3, exceeds max length of 2"
+                "Date range not an object or JSON string."
             )
 
         with self.assertRaises(exceptions.BadRequestException) as e:
-            value = utils.range_filter_parser("[1, 2, 3]")
+            value = utils.range_filter_parser('{"from":null,"to":null,"too":null}')
             self.assertEqual(
                 e.message,
-                "Date range list with length:3, exceeds max length of 2"
+                "Date range object with length:3, exceeds max length of 2"
             )
 
         with self.assertRaises(exceptions.BadRequestException) as e:
-            value = utils.range_filter_parser("[1, 2]")
+            value = utils.range_filter_parser('{"from":1,"to":2,"too":3}')
+            self.assertEqual(
+                e.message,
+                "Date range object with length:3, exceeds max length of 2"
+            )
+
+        with self.assertRaises(exceptions.BadRequestException) as e:
+            value = utils.range_filter_parser('{"from":"1","to":"2"}')
             self.assertEqual(
                 e.message,
                 "Date value(1) does not have correct format YYYY-MM-DD"

--- a/authentication_service/utils.py
+++ b/authentication_service/utils.py
@@ -124,7 +124,7 @@ def range_filter_parser(date_range):
     parsed_range = []
     if not isinstance(date_range, list):
         # Depending on the format of the dates inside, literal_eval will break.
-        # Handle a string argument given if it looks like a string or a list.
+        # Handle a string argument given if it looks like an object or a list.
         if "{" in date_range:
             dates = date_range.replace('"', "").replace(
                 " ", "").replace("{", "").replace("}", "").split(",")
@@ -136,11 +136,10 @@ def range_filter_parser(date_range):
                 "[", "").replace("]", "").split(",")
 
     # On the off chance there are more or less than 2 entries in the list.
-    if len(date_range) >= 2:
+    if len(date_range) > 2:
         raise exceptions.BadRequestException(
             f"Date range list with length:"
-            f"{len(date_range)}, does not meet required length of 2"
-            f"(empty dates are declared by a 'none' string.)"
+            f"{len(date_range)}, exceeds max length of 2"
         )
 
     for date in date_range:
@@ -170,7 +169,7 @@ def range_filter_parser(date_range):
         else:
             parsed_range.append(None)
 
-    # Should contain atleast one not NoneType object.
+    # Should contain at least one not NoneType object.
     if any(set(parsed_range)):
         # We need to pass some hints along to the caller. __range does not
         # support [,date]/[date,]

--- a/authentication_service/utils.py
+++ b/authentication_service/utils.py
@@ -1,4 +1,6 @@
 import datetime
+import json
+import logging
 
 from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
@@ -120,29 +122,27 @@ def to_dict_with_custom_fields(instance, custom_fields):
 
 
 def range_filter_parser(date_range):
-
-    parsed_range = []
-    if not isinstance(date_range, list):
+    parsed_range = {}
+    if isinstance(date_range, str):
         # Depending on the format of the dates inside, literal_eval will break.
-        # Handle a string argument given if it looks like an object or a list.
-        if "{" in date_range:
-            dates = date_range.replace('"', "").replace(
-                " ", "").replace("{", "").replace("}", "").split(",")
-            date_range = ["none", "none"]
-            for date in dates:
-                date_range[0 if "from" in date else 1] = date.split(":", 1)[1]
-        else:
-            date_range = date_range.replace(" ", "").replace(
-                "[", "").replace("]", "").split(",")
+        # Handle a string argument if JSON parse-able.
+        try:
+            date_range = json.loads(date_range, encoding="utf-8")
+        except (ValueError, TypeError) as e:
+            raise SuspiciousOperation(e)
+    elif not isinstance(date_range, dict):
+        raise exceptions.BadRequestException(
+            f"Date range not an object or JSON string."
+        )
 
     # On the off chance there are more or less than 2 entries in the list.
     if len(date_range) > 2:
         raise exceptions.BadRequestException(
-            f"Date range list with length:"
+            f"Date range object with length:"
             f"{len(date_range)}, exceeds max length of 2"
         )
 
-    for date in date_range:
+    for key, date in date_range.items():
         # Preferable to not mix date and datetime objects, make sure all are
         # date objects.
         if isinstance(date, str) and date.lower() != "none":
@@ -157,7 +157,7 @@ def range_filter_parser(date_range):
                     formatted_date = datetime.datetime.strptime(
                         date, "%Y-%m-%d"
                     )
-                parsed_range.append(formatted_date)
+                parsed_range[key] = formatted_date
             except ValueError:
                 raise exceptions.BadRequestException(
                     f"Date value({date}) does not have "
@@ -165,23 +165,24 @@ def range_filter_parser(date_range):
                 )
         elif isinstance(date, datetime.datetime) or isinstance(
                 date, datetime.date):
-            parsed_range.append(date)
+            parsed_range[key] = date
         else:
-            parsed_range.append(None)
+            parsed_range[key] = None
 
     # Should contain at least one not NoneType object.
-    if any(set(parsed_range)):
+    parsed_values = [value for value in parsed_range.values()]
+    if any(parsed_values):
         # We need to pass some hints along to the caller. __range does not
         # support [,date]/[date,]
-        if parsed_range[0] is None:
-            parsed_range = ("lte", parsed_range[1])
-        elif parsed_range[1] is None:
-            parsed_range = ("gte", parsed_range[0])
+        if not parsed_range.get("from"):
+            parsed_range = ("lte", parsed_range["to"])
+        elif not parsed_range.get("to"):
+            parsed_range = ("gte", parsed_range["from"])
         else:
-            parsed_range = ("range", parsed_range)
+            parsed_range = ("range", parsed_values)
     else:
         raise exceptions.BadRequestException(
-            "Date range list does not contain a date object"
+            "Date range object does not contain any date object values"
         )
 
     return parsed_range


### PR DESCRIPTION
*Background*: The GMP date range filter can easily send off an object with either/or/both `to` and `from` attributes in the query parameters. The list route on AOR/ReduxForm is far more unpleasant and hacky.

*What was done*: Changed the date parser to handle a given object parsing it from JSON. Tests also updated.