### PR TITLE
Fixed `createsuperuser` management command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.1.1
+-----
+Fixed bug that made the createsuperuser management command unusable.
+
 1.1.0
 -----
 Added healthcheck API end-point.

--- a/authentication_service/models.py
+++ b/authentication_service/models.py
@@ -95,6 +95,7 @@ class CoreUser(AbstractUser):
         null=True
     )
     migration_data = JSONField(blank=True, default={})
+    REQUIRED_FIELDS = ["birth_date", "email"]
 
     def __init__(self, *args, **kwargs):
         super(CoreUser, self).__init__(*args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ LONG_DESCRIPTION_FILES = ["README.rst", "AUTHORS.rst", "CHANGELOG.rst"]
 
 setup(
     name="authentication_service",
-    version="1.1.0",
+    version="1.1.1",
     description="Girl Effect Core Authentication Service",
     long_description="".join(open(filename, "r").read() for filename in LONG_DESCRIPTION_FILES),
     author="Praekelt Consulting",


### PR DESCRIPTION
`REQUIRED_FIELDS` definition was missing on the `CoreUser` model.
GE-1011 