### PR TITLE
feature/GEINFRA-62: Remove birth_date from form html output

### DIFF
--- a/authentication_service/forms.py
+++ b/authentication_service/forms.py
@@ -467,7 +467,8 @@ class EditProfileForm(forms.ModelForm):
         ]
 
     def _html_output(self, *args, **kwargs):
-        # Django does not allow the exclusion of fields on ModelForm forms.
+        # Exclude fields from the html not the form itself. Makes using built
+        # in save method easier.
 
         # Currently birth_date should not be merely hidden, it causes the
         # browser to send back the original value. Birth date is always used

--- a/authentication_service/forms.py
+++ b/authentication_service/forms.py
@@ -467,7 +467,7 @@ class EditProfileForm(forms.ModelForm):
         ]
 
     def _html_output(self, *args, **kwargs):
-        # Django does not allow the exclusion of fields on none ModelForm forms.
+        # Django does not allow the exclusion of fields on ModelForm forms.
 
         # Currently birth_date should not be merely hidden, it causes the
         # browser to send back the original value. Birth date is always used

--- a/authentication_service/tests/test_forms.py
+++ b/authentication_service/tests/test_forms.py
@@ -742,6 +742,12 @@ class EditProfileFormTestCase(TestCase):
         form = EditProfileForm(instance=self.user, data=data)
         self.assertTrue(form.has_changed())
         self.assertTrue(form.is_valid())
+        form.save()
+
+        user = get_user_model().objects.get(username=self.user.username)
+        self.assertNotEqual(datetime.date(2000, 1, 1), user.birth_date)
+        self.assertEqual(data["email"], user.email)
+        self.assertEqual(data["msisdn"], user.msisdn)
 
     def test_nothing_updated(self):
         data = model_to_dict(self.user)


### PR DESCRIPTION
Edit profile was on face value not working. Turns out it was working for all fields apart from age. This was due to birth_date being passed an initial value and then being hidden on form the browser then ends up posting back.

There was a recent change to age and birth_date logic where all the forms were made to have the same basic functionality regarding those two fields. With that logic came change to edit profile where it no longer assumes that age is the only field present and birth_date value always takes priority when updating the user data.