### PR TITLE
Exclude language variants

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -358,7 +358,7 @@ if not any([IS_WORKER, env.bool("BUILDER", False)]):
         )
     )
 
-# SECURITY WARNING: don"t run with debug turned on in production!
+# SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env.bool("DEBUG", False)
 
 # Attempt to import local settings if present.

--- a/project/settings.py
+++ b/project/settings.py
@@ -36,7 +36,24 @@ LOCALE_PATHS = [
 
 LANGUAGE_CODE = "en"
 
-LANGUAGES = global_settings.LANGUAGES + [
+# We explicitly exclude language variants.
+EXCLUDED_LANGUAGE_CODES = {
+    "en-au",
+    "en-gb",
+    "es-ar",
+    "es-co",
+    "es-mx",
+    "es-ni",
+    "es-ve",
+    "pt-br",
+    "sr-latn",
+    "zh-hans",
+    "zh-hant",
+}
+
+LANGUAGES = [
+    language for language in global_settings.LANGUAGES if language[0] not in EXCLUDED_LANGUAGE_CODES
+] + [
     ("tl", _("Tagalog")),
     ("rw", _("Kinyarwanda")),
     ("ha", _("Hausa")),
@@ -341,7 +358,7 @@ if not any([IS_WORKER, env.bool("BUILDER", False)]):
         )
     )
 
-# SECURITY WARNING: don't run with debug turned on in production!
+# SECURITY WARNING: don"t run with debug turned on in production!
 DEBUG = env.bool("DEBUG", False)
 
 # Attempt to import local settings if present.


### PR DESCRIPTION
# Background
We cannot support translations for all variations of English (American/British/Australian) and other language variants, so we limit languages to the base ones.