### PR TITLE
Handle UserSite creation in the 'user_accept_consent' callback

### DIFF
--- a/authentication_service/app.py
+++ b/authentication_service/app.py
@@ -8,5 +8,7 @@ class AuthAppConfig(AppConfig):
     name = "authentication_service"
 
     def ready(self):
+        # We have to import signals only when the app is ready.
+        from authentication_service import signals
         Field.register_lookup(lookups.Ilike)
 

--- a/authentication_service/oidc_provider_settings.py
+++ b/authentication_service/oidc_provider_settings.py
@@ -90,8 +90,6 @@ class CustomScopeClaims(ScopeClaims):
         """
         # Find the Site ID associated with this Client
         site_id = api_helpers.get_site_for_client(self.client.id)
-        # Make sure we have a UserSite entry, otherwise create one.
-        UserSite.objects.get_or_create({}, user=self.user, site_id=site_id)
 
         LOGGER.debug("Looking up site {} data for user {}".format(
             self.client.client_id, self.user))

--- a/authentication_service/signals.py
+++ b/authentication_service/signals.py
@@ -1,0 +1,19 @@
+import logging
+
+from django.dispatch import receiver
+from oidc_provider.signals import user_accept_consent
+
+from authentication_service import api_helpers
+from authentication_service.models import UserSite
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(user_accept_consent)
+def user_accepted_consent_callback(sender, user, client, **kwargs):
+    site_id = api_helpers.get_site_for_client(client.id)
+    # Make sure we have a UserSite entry, otherwise create one.
+    _, created = UserSite.objects.get_or_create({}, user=user, site_id=site_id)
+    message = "Created UserSite entry for {user} on {client}." if created \
+        else "UserSite entry for {user} on {client} exists."
+    logger.debug(message.format(user=user, client=client))

--- a/project/settings.py
+++ b/project/settings.py
@@ -264,6 +264,7 @@ MAX_LISTING_LIMIT = 100
 MIN_LISTING_LIMIT = 1
 DEFAULT_LISTING_OFFSET = 0
 
+LOG_LEVEL = env.str("LOG_LEVEL", "info").upper()
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": True,
@@ -286,7 +287,7 @@ LOGGING = {
         }
     },
     "loggers": {
-        "root": {
+        "": {
             "level": "WARNING",
             "handlers": ["sentry", "console"],
         },
@@ -310,6 +311,12 @@ LOGGING = {
             "handlers": ["console"],
             "propagate": False,
         },
+        "authentication_service": {
+            "level": LOG_LEVEL,
+            "handlers": ["console", "sentry"],
+            # required to avoid double logging with root logger
+            "propagate": False,
+        }
     },
 }
 


### PR DESCRIPTION
Dealing with it in the "site scope" handler was not sufficient, since a site that forget to add the site scope, or do not use it, will not be handled (as was the case with the Mangement Portal).