### PR TITLE
Only API key authentication should be allowed for API calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,11 +90,12 @@ database:
 	sql/create_database.sh $(DB_NAME) $(DB_USER) | sudo -u postgres psql -f -
 
 test:
-	$(PYTHON) manage.py test --settings=authentication_service.tests.settings.111
+	ALLOWED_API_KEYS=test-api-key,some-other-api-key USER_DATA_STORE_API=local.uds USER_DATA_STORE_API_KEY=uds-test-api-key ACCESS_CONTROL_API=local.acs ACCESS_CONTROL_API_KEY=acs-test-api-key $(PYTHON) manage.py test --settings=authentication_service.tests.settings.111
 
 authentication-service-api: $(VENV)
 	$(VENV)/bin/pip install -r $(VENV)/src/swagger-django-generator/requirements.txt
-	$(PYTHON) $(VENV)/src/swagger-django-generator/swagger_django_generator/generator.py swagger/authentication_service.yml --output-dir authentication_service/api --module-name authentication_service.api
+	# The utils file must not be overwritten, hence "--utils-file /dev/null"
+	$(PYTHON) $(VENV)/src/swagger-django-generator/swagger_django_generator/generator.py swagger/authentication_service.yml --output-dir authentication_service/api --module-name authentication_service.api --utils-file /dev/null
 
 make-translations:
 	@echo "$(CYAN)Ensuring that language directories exists...$(CLEAR)"

--- a/authentication_service/api/utils.py
+++ b/authentication_service/api/utils.py
@@ -45,25 +45,7 @@ def login_required_no_redirect(view_func):
     """
     @wraps(view_func)
     def wrapper(request, *args, **kwargs):
-        if request.user.is_authenticated:
-            return view_func(request, *args, **kwargs)
-
-        if "HTTP_AUTHORIZATION" in request.META:
-            auth = request.META["HTTP_AUTHORIZATION"].split()
-            if len(auth) == 2:
-                # NOTE: We only support basic authentication for now.
-                if auth[0].lower() == "basic":
-                    base_val = base64.b64decode(auth[1])
-                    if sys.version_info[0] > 2:
-                        uname, passwd = base_val.split(b":")
-                    else:
-                        uname, passwd = base_val.split(":")
-                    user = authenticate(username=uname, password=passwd)
-                    if user and user.is_active:
-                        login(request, user)
-                        request.user = user
-                        return view_func(request, *args, **kwargs)
-
+        # For API calls, the only authentication mechanism allowed is the API key
         if "HTTP_X_API_KEY" in request.META:
             key = request.META["HTTP_X_API_KEY"]
             if key in settings.ALLOWED_API_KEYS:


### PR DESCRIPTION
# Background
API calls were allowed for users that are logged in or used basic HTTP auth. This should not be allowed.

# What was done
Restrict API authentication to only look at HTTP header auth. The `utils.py` file that gets generated by the `swagger-django-generator` is sent to `/dev/null` so that we preserve the `utils.py` that only allows the HTTP header auth.
Tests were updated to use the auth header.