### PR TITLE
Added API definition for the 'request_user_deletion' end-point

### DIFF
--- a/authentication_service/api/schemas.py
+++ b/authentication_service/api/schemas.py
@@ -161,6 +161,30 @@ organisation_update = json.loads("""
 }
 """)
 
+request_user_deletion = json.loads("""
+{
+    "properties": {
+        "deleter_id": {
+            "format": "uuid",
+            "type": "string"
+        },
+        "reason": {
+            "type": "string"
+        },
+        "user_id": {
+            "format": "uuid",
+            "type": "string"
+        }
+    },
+    "required": [
+        "user_id",
+        "deleter_id",
+        "reason"
+    ],
+    "type": "object"
+}
+""")
+
 user = json.loads("""
 {
     "properties": {

--- a/authentication_service/api/stubs.py
+++ b/authentication_service/api/stubs.py
@@ -140,6 +140,16 @@ class AbstractStubClass(object):
         """
         raise NotImplementedError()
 
+    # request_user_deletion -- Synchronisation point for meld
+    @staticmethod
+    def request_user_deletion(request, body, *args, **kwargs):
+        """
+        :param request: An HttpRequest
+        :param body: A dictionary containing the parsed and validated body
+        :type body: dict
+        """
+        raise NotImplementedError()
+
     # user_list -- Synchronisation point for meld
     @staticmethod
     def user_list(request, offset=None, limit=None, birth_date=None, country=None, date_joined=None, email=None, email_verified=None, first_name=None, gender=None, is_active=None, last_login=None, last_name=None, msisdn=None, msisdn_verified=None, nickname=None, organisation_id=None, updated_at=None, username=None, q=None, tfa_enabled=None, has_organisation=None, order_by=None, user_ids=None, site_ids=None, *args, **kwargs):
@@ -544,6 +554,22 @@ class MockedStubClass(AbstractStubClass):
         :type organisation_id: integer
         """
         response_schema = schemas.organisation
+        if "type" not in response_schema:
+            response_schema["type"] = "object"
+
+        if response_schema["type"] == "array" and "type" not in response_schema["items"]:
+            response_schema["items"]["type"] = "object"
+
+        return MockedStubClass.GENERATOR.random_value(response_schema)
+
+    @staticmethod
+    def request_user_deletion(request, body, *args, **kwargs):
+        """
+        :param request: An HttpRequest
+        :param body: A dictionary containing the parsed and validated body
+        :type body: dict
+        """
+        response_schema = schemas.__UNSPECIFIED__
         if "type" not in response_schema:
             response_schema["type"] = "object"
 

--- a/authentication_service/api/urls.py
+++ b/authentication_service/api/urls.py
@@ -11,6 +11,7 @@ import authentication_service.api.views as views
 urlpatterns = [
     url(r"^users/(?P<user_id>.+)$", views.UsersUserId.as_view()),
     url(r"^users$", views.Users.as_view()),
+    url(r"^request_user_deletion$", views.RequestUserDeletion.as_view()),
     url(r"^organisations/(?P<organisation_id>.+)$", views.OrganisationsOrganisationId.as_view()),
     url(r"^organisations$", views.Organisations.as_view()),
     url(r"^invitations/purge_expired$", views.InvitationsPurgeExpired.as_view()),

--- a/authentication_service/api/views.py
+++ b/authentication_service/api/views.py
@@ -1686,6 +1686,7 @@ class __SWAGGER_SPEC__(View):
                     {
                         "in": "body",
                         "name": "data",
+                        "required": true,
                         "schema": {
                             "$ref": "#/definitions/request_user_deletion",
                             "x-scope": [

--- a/authentication_service/api/views.py
+++ b/authentication_service/api/views.py
@@ -549,27 +549,7 @@ class OrganisationsOrganisationId(View):
 class RequestUserDeletion(View):
 
     POST_RESPONSE_SCHEMA = schemas.__UNSPECIFIED__
-    POST_BODY_SCHEMA = json.loads("""{
-    "properties": {
-        "deleter_id": {
-            "format": "uuid",
-            "type": "string"
-        },
-        "reason": {
-            "type": "string"
-        },
-        "user_id": {
-            "format": "uuid",
-            "type": "string"
-        }
-    },
-    "required": [
-        "user_id",
-        "deleter_id",
-        "reason"
-    ],
-    "type": "object"
-}""")
+    POST_BODY_SCHEMA = schemas.request_user_deletion
 
     def post(self, request, *args, **kwargs):
         """
@@ -1012,6 +992,27 @@ class __SWAGGER_SPEC__(View):
                     "type": "string"
                 }
             },
+            "type": "object"
+        },
+        "request_user_deletion": {
+            "properties": {
+                "deleter_id": {
+                    "format": "uuid",
+                    "type": "string"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "format": "uuid",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "user_id",
+                "deleter_id",
+                "reason"
+            ],
             "type": "object"
         },
         "user": {
@@ -1686,25 +1687,10 @@ class __SWAGGER_SPEC__(View):
                         "in": "body",
                         "name": "data",
                         "schema": {
-                            "properties": {
-                                "deleter_id": {
-                                    "format": "uuid",
-                                    "type": "string"
-                                },
-                                "reason": {
-                                    "type": "string"
-                                },
-                                "user_id": {
-                                    "format": "uuid",
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "user_id",
-                                "deleter_id",
-                                "reason"
-                            ],
-                            "type": "object"
+                            "$ref": "#/definitions/request_user_deletion",
+                            "x-scope": [
+                                ""
+                            ]
                         }
                     }
                 ],

--- a/authentication_service/api/views.py
+++ b/authentication_service/api/views.py
@@ -563,6 +563,11 @@ class RequestUserDeletion(View):
             "type": "string"
         }
     },
+    "required": [
+        "user_id",
+        "deleter_id",
+        "reason"
+    ],
     "type": "object"
 }""")
 
@@ -1694,6 +1699,11 @@ class __SWAGGER_SPEC__(View):
                                     "type": "string"
                                 }
                             },
+                            "required": [
+                                "user_id",
+                                "deleter_id",
+                                "reason"
+                            ],
                             "type": "object"
                         }
                     }

--- a/authentication_service/integration.py
+++ b/authentication_service/integration.py
@@ -175,6 +175,20 @@ class Implementation(AbstractStubClass):
 
         return {}
 
+    @staticmethod
+    def purge_expired_invitations(request, cutoff_date=None, *args, **kwargs):
+        """
+        :param request: An HttpRequest
+        :param cutoff_date: (optional) An optional cutoff date to purge invites before this date
+        :type cutoff_date: string
+        """
+        if cutoff_date is None:
+            cutoff_date = str(datetime.datetime.now().date())
+        tasks.purge_expired_invitations.apply_async(
+            cutoff_date=cutoff_date
+        )
+        return
+
     # organisation_list -- Synchronisation point for meld
     @staticmethod
     def organisation_list(request, offset=None, limit=None, organisation_ids=None, *args, **kwargs):
@@ -271,6 +285,16 @@ class Implementation(AbstractStubClass):
         organisation.save()
         result = to_dict_with_custom_fields(organisation, ORGANISATION_VALUES)
         return strip_empty_optional_fields(result)
+
+    # request_user_deletion -- Synchronisation point for meld
+    @staticmethod
+    def request_user_deletion(request, body, *args, **kwargs):
+        """
+        :param request: An HttpRequest
+        :param body: A dictionary containing the parsed and validated body
+        :type body: dict
+        """
+        raise NotImplementedError()
 
     # user_list -- Synchronisation point for meld
     @staticmethod
@@ -461,17 +485,3 @@ class Implementation(AbstractStubClass):
         instance.save()
         result = to_dict_with_custom_fields(instance, USER_VALUES)
         return strip_empty_optional_fields(result)
-
-    @staticmethod
-    def purge_expired_invitations(request, cutoff_date=None, *args, **kwargs):
-        """
-        :param request: An HttpRequest
-        :param cutoff_date: An optional cutoff date to purge invites before this date
-        :type cutoff_date: date
-        """
-        if cutoff_date is None:
-            cutoff_date = str(datetime.datetime.now().date())
-        tasks.purge_expired_invitations.apply_async(
-            cutoff_date=cutoff_date
-        )
-        return

--- a/swagger/authentication_service.yml
+++ b/swagger/authentication_service.yml
@@ -1063,6 +1063,7 @@ paths:
           name: data
           schema:
             $ref: '#/definitions/request_user_deletion'
+          required: true
       produces:
         - application/json
       responses:

--- a/swagger/authentication_service.yml
+++ b/swagger/authentication_service.yml
@@ -1058,6 +1058,10 @@ paths:
                 format: uuid
               reason:
                 type: string
+            required:
+              - user_id
+              - deleter_id
+              - reason
       produces:
         - application/json
       responses:

--- a/swagger/authentication_service.yml
+++ b/swagger/authentication_service.yml
@@ -334,7 +334,21 @@ definitions:
       - consented_at
       - created_at
       - updated_at
-
+  request_user_deletion:
+    type: object
+    properties:
+      user_id:
+        type: string
+        format: uuid
+      deleter_id:
+        type: string
+        format: uuid
+      reason:
+        type: string
+    required:
+      - user_id
+      - deleter_id
+      - reason
 
 #  Token:
 #    description: |
@@ -1048,20 +1062,7 @@ paths:
         - in: body
           name: data
           schema:
-            type: object
-            properties:
-              user_id:
-                type: string
-                format: uuid
-              deleter_id:
-                type: string
-                format: uuid
-              reason:
-                type: string
-            required:
-              - user_id
-              - deleter_id
-              - reason
+            $ref: '#/definitions/request_user_deletion'
       produces:
         - application/json
       responses:

--- a/swagger/authentication_service.yml
+++ b/swagger/authentication_service.yml
@@ -335,6 +335,7 @@ definitions:
       - created_at
       - updated_at
 
+
 #  Token:
 #    description: |
 #      Successful token response
@@ -1035,6 +1036,33 @@ paths:
           description: 'Began task to purge invitations.'
         403:
           description: 'Forbidden'
+      tags:
+        - authentication
+
+  /request_user_deletion:
+    post:
+      operationId: request_user_deletion
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: data
+          schema:
+            type: object
+            properties:
+              user_id:
+                type: string
+                format: uuid
+              deleter_id:
+                type: string
+                format: uuid
+              reason:
+                type: string
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
       tags:
         - authentication
 


### PR DESCRIPTION
This is just the Swagger definition and related stubs. The function has not been implemented.
Note: I moved the implementation of the `purge_expired_invitations` function to match the position in the generated stubs file.