### PR TITLE
Feature/geinfra 119

### DIFF
--- a/authentication_service/forms.py
+++ b/authentication_service/forms.py
@@ -102,13 +102,13 @@ class RegistrationForm(UserCreationForm):
             field.label = _("Oragnisation user has been invited to:")
 
             # Override widget templates
-            widget.template_name = "authentication_service/widgets/select.html"
+            widget.template_name = "authentication_service/widgets/options_display_only.html"
 
-            # Dango form renderers patches the BoundField.css_classes() method
+            # Dango form renderer patches the BoundField.css_classes() method
             # to include the bound field name as part of the classes. This is a
-            # special case where organisation needs to be introduced relatively
-            # risk free, we require the normal underlying field to still behave
-            # as a ModelChoice field.
+            # special case where we want the underlying functionalityof the
+            # ModelChoice field without any of its front end components or
+            # styling.
             self["organisation"].field.__class__.__name__ = \
                 "OverridenBoundFieldClassName"
         else:

--- a/authentication_service/forms.py
+++ b/authentication_service/forms.py
@@ -66,19 +66,54 @@ class RegistrationForm(UserCreationForm):
     class Meta:
         model = get_user_model()
         fields = [
+            # Org field should never be directly editable via the form
+            "organisation",
             "username", "avatar", "first_name", "last_name", "email",
             "nickname", "msisdn", "gender", "age", "birth_date",
             "country", "password1", "password2"
         ]
         exclude = ["terms",]
 
-    def __init__(self, terms_url=None, security=None, required=None, hidden=None, *args, **kwargs):
+    def __init__(self, terms_url=None, security=None, required=None,
+            hidden=None, organisation_id=None, *args, **kwargs):
         # Super needed before we can actually update the form.
         super(RegistrationForm, self).__init__(*args, **kwargs)
         self.terms_url = terms_url or GE_TERMS_URL
 
         # Security value is required later in form processes as well.
         self.security = security
+
+        # Organisation field setup and tweaking
+        if organisation_id:
+            # Oganisation is a special field, it was never meant to be user
+            # editable. Disabled and alter specific attributes manually.
+            field = self.fields["organisation"]
+            widget = field.widget
+
+            # Remove all other choices and ready cleaned_data value
+            filtered_choices = widget.choices.queryset.filter(
+                id=organisation_id
+            )
+            widget.choices.queryset = filtered_choices
+            self.organisation = filtered_choices.first()
+
+            # Update some field attributes
+            field.empty_label = None
+            field.label = _("Oragnisation user has been invited to:")
+
+            # Override widget templates
+            widget.template_name = "authentication_service/widgets/select.html"
+
+            # Dango form renderers patches the BoundField.css_classes() method
+            # to include the bound field name as part of the classes. This is a
+            # special case where organisation needs to be introduced relatively
+            # risk free, we require the normal underlying field to still behave
+            # as a ModelChoice field.
+            self["organisation"].field.__class__.__name__ = \
+                "OverridenBoundFieldClassName"
+        else:
+            # Fully remove field if no organisation id was provided
+            self.fields.pop("organisation")
 
         # Set update form update variables, for manipulation as init
         # progresses.
@@ -237,6 +272,9 @@ class RegistrationForm(UserCreationForm):
                 _("Password not long enough.")
             )
         return password2
+
+    def clean_organisation(self):
+        return self.organisation
 
     def _get_validation_exclusions(self):
         # By default fields that are allowed to be blank on the model are not

--- a/authentication_service/forms.py
+++ b/authentication_service/forms.py
@@ -106,9 +106,9 @@ class RegistrationForm(UserCreationForm):
 
             # Dango form renderer patches the BoundField.css_classes() method
             # to include the bound field name as part of the classes. This is a
-            # special case where we want the underlying functionalityof the
-            # ModelChoice field without any of its front end components or
-            # styling.
+            # special case where the underlying functionality of the
+            # ModelChoice field is to be used, without any of its front end
+            # components or styling.
             self["organisation"].field.__class__.__name__ = \
                 "OverridenBoundFieldClassName"
         else:

--- a/authentication_service/forms.py
+++ b/authentication_service/forms.py
@@ -110,7 +110,7 @@ class RegistrationForm(UserCreationForm):
             # ModelChoice field is to be used, without any of its front end
             # components or styling.
             self["organisation"].field.__class__.__name__ = \
-                "OverridenBoundFieldClassName"
+                "ARB_BOUND_FIELD_NAME_TO_AVOID_PATCHING"
         else:
             # Fully remove field if no organisation id was provided
             self.fields.pop("organisation")

--- a/authentication_service/templates/authentication_service/widgets/options_display_only.html
+++ b/authentication_service/templates/authentication_service/widgets/options_display_only.html
@@ -1,0 +1,8 @@
+{# Template for widget that will only display its options as clear text and have no otehr functionality #}
+<div>
+    {% for group_name, group_choices, group_index in widget.optgroups %}
+        {% for option in group_choices %}
+            <p>{{ option.label }}</p>
+        {% endfor %}
+    {% endfor %}
+</div>

--- a/authentication_service/templates/authentication_service/widgets/options_display_only.html
+++ b/authentication_service/templates/authentication_service/widgets/options_display_only.html
@@ -1,4 +1,4 @@
-{# Template for widget that will only display its options as clear text and have no otehr functionality #}
+{# Template for widget that will only display its options as clear text and have no other functionality #}
 <div>
     {% for group_name, group_choices, group_index in widget.optgroups %}
         {% for option in group_choices %}

--- a/authentication_service/views.py
+++ b/authentication_service/views.py
@@ -298,7 +298,7 @@ class RegistrationWizard(LanguageMixin, NamedUrlSessionWizardView):
             initial = {
                 "first_name": invitation.get("first_name"),
                 "last_name": invitation.get("last_name"),
-                "email": invitation.get("email")
+                "email": invitation.get("email"),
             }
         # Formsets take a list of dictionaries for initial data.
         if step == "securityquestions":
@@ -313,7 +313,7 @@ class RegistrationWizard(LanguageMixin, NamedUrlSessionWizardView):
             "security": self.request.GET.get("security"),
             "required": self.request.GET.getlist("requires"),
             "hidden": self.request.GET.getlist("hide"),
-            "question_ids": self.request.GET.getlist("question_ids", [])
+            "question_ids": self.request.GET.getlist("question_ids", []),
         }
 
         custom_kwargs.update(
@@ -326,6 +326,7 @@ class RegistrationWizard(LanguageMixin, NamedUrlSessionWizardView):
                 self.storage.extra_data[key] = value
 
         kwargs = super(RegistrationWizard, self).get_form_kwargs()
+        kwargs["organisation_id"] = 1
         if step == "userdata":
             security = self.storage.extra_data.get("security")
             hidden = self.storage.extra_data.get("hidden")


### PR DESCRIPTION
Make use of underlying ModelForm used by registration to save the organisation.

- Removed saving logic from the view
- Display the organisation the user has been invited to by manipulating the default ModelChoice field attrs.