### PR TITLE
feature/GEINFRA-351: Show success page with option to go back to clie…

### DIFF
--- a/authentication_service/tests/test_views.py
+++ b/authentication_service/tests/test_views.py
@@ -1052,7 +1052,9 @@ class TestRegistrationView(TestCase):
         # self.assertin(response.url, reverse("two_factor_auth:setup"))
         self.assertEquals(response.redirect_chain[-1][0], "/test-redirect-url/")
 
-    def test_view_success_redirects_security_high(self):
+    @patch("ge_event_log.events.api_helpers.get_site_for_client")
+    def test_view_success_redirects_security_high(self, api_mock):
+        api_mock.return_value = 2
         response = self.client.get(
             reverse(
                 "registration"


### PR DESCRIPTION
…nt on pwd reset success pages

Also fix a case where a session variable was not getting correctly cleared.

![screenshot_2018-11-14 password update success](https://user-images.githubusercontent.com/10414305/48484552-15130b80-e81f-11e8-94cd-48644bc14f51.png)
